### PR TITLE
Update dbt_cloud_environment_variable.md

### DIFF
--- a/docs/resources/dbt_cloud_environment_variable.md
+++ b/docs/resources/dbt_cloud_environment_variable.md
@@ -18,7 +18,9 @@ the same time as the environment variables, it's recommended to use the `depends
 
 ### Required
 
-- `environment_values` (Map of String) Map from environment names to respective variable value, a special key `project` should be set for the project default variable value
+- `environment_values` (Map of String) Map from environment names to respective variable value
+     - Environment names should be title cased, for eg: 'Production', 'Development'
+     - A special key `project` should be set for the project default variable value
 - `name` (String) Name for the variable, must be unique within a project, must be prefixed with 'DBT_'
 - `project_id` (Number) Project for the variable to be created in
 


### PR DESCRIPTION
Add a note to title-case environment names. If we don't title-casing the environment names, it can throw a 500 error when we run `terraform apply`. For eg: if we are setting the environment variables for the Production env, the environment name should also be `Production`.

Related - https://github.com/GtheSheep/terraform-provider-dbt-cloud/issues/108#issue-1586440179